### PR TITLE
Update wiki.kak

### DIFF
--- a/rc/wiki.kak
+++ b/rc/wiki.kak
@@ -97,7 +97,7 @@ define-command wiki_follow_link \
             <a-i>b
         }
         evaluate-commands -try-client %opt{jumpclient} edit -existing %sh{
-            echo "${kak_buffile%/*.md}/$kak_selection"
+            echo "'${kak_buffile%/*.md}/$kak_selection'"
         }
         try %{ focus %opt{jumpclient} }
     }


### PR DESCRIPTION
Fixed a small bug where folders with spaces in their names cause the `wiki_follow_link` function to pass the file path incorrectly to the edit function.
Thank you @TeddyDD for the plugin!